### PR TITLE
Add support for Sony Xperia X (untested)

### DIFF
--- a/src/cmon.cpp
+++ b/src/cmon.cpp
@@ -216,7 +216,9 @@ bool Cmon::checkDevice()
 
         res = true;
     }
-    else if (outArgs.at(0).toString() == "f5321")  /* Sony Xperia X Compact */
+    else if (outArgs.at(0).toString() == "f5121" || /* Sony Xperia X */
+             outArgs.at(0).toString() == "f5122" || /* Sony Xperia X dual SIM */
+             outArgs.at(0).toString() == "f5321")  /* Sony Xperia X Compact */
     {
         generalValues.clear();
         generalValues << "";

--- a/src/cmon.cpp
+++ b/src/cmon.cpp
@@ -119,6 +119,30 @@ bool Cmon::checkDevice()
 
         res = true;
     }
+    else if (outArgs.at(0).toString() == "JT-1501") /* The one and only original Jolla tablet */
+    {
+        generalValues.clear();
+        generalValues << "";
+        generalValues << ""; /* No reliable USB voltage */
+        generalValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/current_now";
+        generalValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/voltage_now";
+        generalValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/capacity";
+        generalValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/temp";
+
+        infoPageValues.clear();
+        infoPageValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/status";
+        infoPageValues << "";
+        infoPageValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/health";
+        infoPageValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/technology";
+        infoPageValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_charger/power_supply/dollar_cove_charger/type";
+        infoPageValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_charger/power_supply/dollar_cove_charger/max_charge_current";
+
+        infoPageRawValues.clear();
+        infoPageRawValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/charge_full";
+        infoPageRawValues << "/sys/devices/platform/80860F41:04/i2c-5/5-0034/dollar_cove_battery/power_supply/dollar_cove_battery/charge_full_design";
+
+        res = true;
+    }
     else if (outArgs.at(0).toString() == "onyx") /* OneplusX */
     {
         generalValues.clear();
@@ -356,7 +380,10 @@ QString Cmon::readDcinVoltage()
 
 QString Cmon::readUsbinVoltage()
 {
-    return QString::number(m_usbinvoltage) + " V";
+    if (deviceName == "JT-1501")
+        return QString("N/A");
+    else
+        return QString::number(m_usbinvoltage) + " V";
 }
 
 QString Cmon::readBatteryVoltage()

--- a/src/cmon.cpp
+++ b/src/cmon.cpp
@@ -216,6 +216,30 @@ bool Cmon::checkDevice()
 
         res = true;
     }
+    else if (outArgs.at(0).toString() == "f5321")  /* Sony Xperia X Compact */
+    {
+        generalValues.clear();
+        generalValues << "";
+        generalValues << "/sys/devices/soc.0/*.usb/power_supply/usb/voltage_now";
+        generalValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/current_now";
+        generalValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/voltage_now";
+        generalValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/capacity";
+        generalValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/temp";
+
+        infoPageValues.clear();
+        infoPageValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/status";
+        infoPageValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/charge_type";
+        infoPageValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/health";
+        infoPageValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/technology";
+        infoPageValues << "/sys/devices/soc.0/*.usb/power_supply/usb/type";
+        infoPageValues << "/sys/devices/soc.0/*.usb/power_supply/usb/current_max";
+
+        infoPageRawValues.clear();
+        infoPageRawValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/charge_full";
+        infoPageRawValues << "/sys/devices/soc.0/*-qcom,qpnp-smbcharger/power_supply/battery/charge_full_design";
+
+        res = true;
+    }
 
     glob(&generalValues);
     glob(&infoPageValues);


### PR DESCRIPTION
Since the Sony Xperia X and the Compact should be quite similar, this PR just adds the Xperia X model numbers (F5121/F5122) to be handled the same way as Xperia X Compact, which is added in PR #4. I don't have any Xperia X myself, so this is untested. Would be great if someone could test this before the PR is merged. For convenience, I have put the RPM I built [here](https://jirafeau.net/f.php?h=2Jsf0T_k&d=1).