### PR TITLE
Xperia 10iii

### DIFF
--- a/harbour-chargemon.desktop
+++ b/harbour-chargemon.desktop
@@ -5,3 +5,7 @@ Name=Charge monitor
 Icon=harbour-chargemon
 Exec=harbour-chargemon
 
+[X-Sailjail]
+Sandboxing=Disabled
+OrganizationName=com.kimmoli
+ApplicationName=harbour-chargemon

--- a/src/cmon.cpp
+++ b/src/cmon.cpp
@@ -351,7 +351,8 @@ bool Cmon::checkDevice()
 
         res = true;
     }
-    else if (deviceName == "fp3")
+    else if (deviceName == "fp3" || /* Fairphone 3 */
+             deviceName == "xqbt52"    /* Sony Xperia 10iii dual SIM */)
     {
         generalValues.clear();
         generalValues << "";
@@ -375,7 +376,6 @@ bool Cmon::checkDevice()
 
         res = true;
     }
-
     glob(&generalValues);
     glob(&infoPageValues);
     glob(&infoPageRawValues);


### PR DESCRIPTION
- turns out Xperia 10iii has the same paths as Fairphone 3
- Xperia 10iii runs on Sailfish 4.4 .0.68 Vahna Rauma - which has mandatory Sailjail for all app => adding a Sailjail section to .desktop (currently it merely deactivates any restriction)